### PR TITLE
yooh-Patch-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ reporter.start(1000);
 ```
 
 **Reporting different metric types**
-Examples can be found in [support/reference](metric type examples).
+Examples can be found in [support/reference/](metric type examples).
 
 **Adding a counter**
 ```javascript

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ reporter.start(1000);
 ```
 
 **Reporting different metric types**
-Examples can be found in [support/reference/](metric type examples).
+Examples can be found in [support/reference/](support/reference/).
 
 **Adding a counter**
 ```javascript

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ reporter.start(1000);
 ```
 
 **Reporting different metric types**
-Examples can be found in [unit/](helper_tags.js).
+Examples can be found in [support/reference](metric type examples).
 
 **Adding a counter**
 ```javascript


### PR DESCRIPTION
Fixed the obsolete link on README.md to point to the correct location for list of examples of each metric types and its usage.