### PR TITLE
Makes wavefront tagging support escaped values, adds tagging support to console reporter

### DIFF
--- a/metrics/meter.js
+++ b/metrics/meter.js
@@ -14,9 +14,6 @@ var Meter = module.exports = function Meter(tags) {
   }else{
     this.tags = {}
   }
-  if(!(Object.keys(this.tags).length === 0 && this.tags.constructor === Object)){
-    console.log('Meter tag string: %s', this.tags);
-  }
 }
 
 // Mark the occurence of n events

--- a/reporting/console-reporter.js
+++ b/reporting/console-reporter.js
@@ -71,12 +71,12 @@ function ff(value) {
 }
 
 function printCounter(counter) {
-  console.log(counter.name);
+  console.log(counter.name, tagger(counter.tags || {}));
   console.log('             count = %d', counter.count);
 }
 
 function printMeter(meter) {
-  console.log(meter.name);
+  console.log(meter.name, tagger(meter.tags || {}));
   console.log('             count = %d', meter.count);
   console.log('         mean rate = %s events/%s', ff(meter.meanRate()), 'second');
   console.log('     1-minute rate = %s events/%s', ff(meter.oneMinuteRate()), 'second');
@@ -85,7 +85,7 @@ function printMeter(meter) {
 }
 
 function printTimer(timer) {
-  console.log(timer.name);
+  console.log(timer.name, tagger(timer.tags || {}));
   console.log('             count = %d', timer.count());
   console.log('         mean rate = %s events/%s', ff(timer.meanRate()), 'second');
   console.log('     1-minute rate = %s events/%s', ff(timer.oneMinuteRate()), 'second');
@@ -100,7 +100,7 @@ function printHistogram(histogram) {
   if(isHisto) {
     // log name and count if a histogram, otherwise assume this metric is being
     // printed as part of another (like a timer).
-    console.log(histogram.name);
+    console.log(histogram.name, tagger(histogram.tags || {}));
     console.log('             count = %d', histogram.count);
   }
 
@@ -120,5 +120,18 @@ function printHistogram(histogram) {
   console.log('            99.9%% <= %s%s', ff(percentiles[.999]), durationUnit);
 }
 
-module.exports = ConsoleReporter;
+function tagger(tags) {
+  var str = '';
+    for (var p in tags) {
+        if (tags.hasOwnProperty(p)) {
+            str += p + '=\"' + escapeQuotes(tags[p]) + '\" ';
+        }
+    }
+    return str;
+}
 
+function escapeQuotes(str) {
+  return str.replace(/\"/g, "\\\"");
+}
+
+module.exports = ConsoleReporter;

--- a/reporting/wavefront-reporter.js
+++ b/reporting/wavefront-reporter.js
@@ -169,21 +169,25 @@ WavefrontReporter.prototype.reportHistogram = function(histogram, timestamp) {
 };
 
 function tagger(tags,globaltags) {
-  //return tags in the format "env=prod service=qa"
+  //return tags in the format 'env="prod" service="qa"'
   //It also merges the global tags with the metric tags
   var str = '';
     for (var p in tags) {
         if (tags.hasOwnProperty(p)) {
-            str += p + '=' + tags[p] + ' ';
+            str += p + '=\"' + escapeQuotes(tags[p]) + '\" ';
         }
     }
     for (var p in globaltags) {
         if (globaltags.hasOwnProperty(p)) {
-            str += p + '=' + globaltags[p] + ' ';
+            str += p + '=\"' + escapeQuotes(globaltags[p]) + '\" ';
         }
     }
     //console.log('tag string: %s', str);
     return str;
+}
+
+function escapeQuotes(str) {
+  return str.replace(/\"/g, "\\\"");
 }
 
 function isEmpty(value) {

--- a/reporting/wavefront-reporter.js
+++ b/reporting/wavefront-reporter.js
@@ -103,7 +103,7 @@ WavefrontReporter.prototype.send = function(name, value, timestamp, tags) {
     return;
   }
   if (!tags) { tags = ''; }
-  console.log(util.format('%s.%s ', this.prefix, name), value,timestamp, tags);
+  // console.log(util.format('%s.%s ', this.prefix, name), value,timestamp, tags);
   this.socket.write(util.format('%s.%s %s %s %s\n', this.prefix, name, value,
     timestamp, tags));
 };
@@ -111,7 +111,7 @@ WavefrontReporter.prototype.send = function(name, value, timestamp, tags) {
 WavefrontReporter.prototype.reportCounter = function(counter, timestamp) {
   var send = this.send.bind(this);
   var tags = tagger(counter.tags,this.globaltags);
-  console.log(util.format('%s.%s', counter.name, 'count'), counter.count, timestamp, tags);
+  // console.log(util.format('%s.%s', counter.name, 'count'), counter.count, timestamp, tags);
   send(counter.name, counter.count, timestamp, tags);
 };
 

--- a/test/unit/console_reporter.js
+++ b/test/unit/console_reporter.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect
   , describe = require('mocha').describe
   , helper = require('./helper.js')
+  , helper_tags = require('./helper_tags.js')
   , it = require('mocha').it
   , util = require('util')
   , os = require('os')
@@ -31,11 +32,11 @@ describe('ConsoleReporter', function () {
     // unanticipated changes affect reported output.
     expect(data.length).to.equal(44);
     expect(data[0]).to.equal('Counters -----------------------------------------------------------------------');
-    expect(data[1]).to.equal('basicCount');
+    expect(data[1]).to.equal('basicCount ');
     expect(data[2]).to.equal('             count = 5');
     expect(data[3]).to.equal('');
     expect(data[4]).to.equal('Meters -------------------------------------------------------------------------');
-    expect(data[5]).to.equal('myapp.Meter');
+    expect(data[5]).to.equal('myapp.Meter ');
     expect(data[6]).to.equal('             count = 10');
     // can't definitively assert the exact mean rate since time elapsed is unknown.
     expect(data[7]).to.match(/         mean rate = .* events\/second/);
@@ -44,7 +45,7 @@ describe('ConsoleReporter', function () {
     expect(data[10]).to.equal('    15-minute rate =  0.00 events/second');
     expect(data[11]).to.equal('');
     expect(data[12]).to.equal('Timers -------------------------------------------------------------------------');
-    expect(data[13]).to.equal('myapp.Timer');
+    expect(data[13]).to.equal('myapp.Timer ');
     expect(data[14]).to.equal('             count = 100');
     expect(data[15]).to.match(/         mean rate = .* events\/second/);
     expect(data[16]).to.equal('     1-minute rate =  0.00 events/second');
@@ -62,7 +63,77 @@ describe('ConsoleReporter', function () {
     expect(data[28]).to.equal('            99.9% <= 100.00 milliseconds');
     expect(data[29]).to.equal('');
     expect(data[30]).to.equal('Histograms ---------------------------------------------------------------------');
-    expect(data[31]).to.equal('myapp.Histogram');
+    expect(data[31]).to.equal('myapp.Histogram ');
+    expect(data[32]).to.equal('             count = 100');
+    expect(data[33]).to.equal('               min =  2.00');
+    expect(data[34]).to.equal('               max = 200.00');
+    expect(data[35]).to.equal('              mean = 101.00');
+    expect(data[36]).to.equal('            stddev = 58.02');
+    expect(data[37]).to.equal('              50% <= 101.00');
+    expect(data[38]).to.equal('              75% <= 151.50');
+    expect(data[39]).to.equal('              95% <= 191.90');
+    expect(data[40]).to.equal('              98% <= 197.96');
+    expect(data[41]).to.equal('              99% <= 199.98');
+    expect(data[42]).to.equal('            99.9% <= 200.00');
+    expect(data[43]).to.equal('');
+  });
+
+  it ('should report to console with tags', function () {
+    // keep track of original log.
+    var olog = console.log;
+
+    // override console.log to capture lines logged.
+    var data = [];
+    console.log = function log() {
+      var args = Array.prototype.slice.call(arguments);
+      var msg = util.format.apply(util, args);
+      data.push(msg);
+    };
+
+    // report sample report and capture stdout.
+    var report = helper_tags.getSampleReport();
+    var reporter = new ConsoleReporter(report);
+    reporter.report();
+
+    // reset console.log.
+    console.log = olog;
+
+    // validate line by line.  This may be overkill but will detect when
+    // unanticipated changes affect reported output.
+    expect(data.length).to.equal(44);
+    expect(data[0]).to.equal('Counters -----------------------------------------------------------------------');
+    expect(data[1]).to.equal('basicCount tag1-counter="countertag_helper" ');
+    expect(data[2]).to.equal('             count = 5');
+    expect(data[3]).to.equal('');
+    expect(data[4]).to.equal('Meters -------------------------------------------------------------------------');
+    expect(data[5]).to.equal('myapp.Meter tag1-meter="metertag_helper" ');
+    expect(data[6]).to.equal('             count = 10');
+    // can't definitively assert the exact mean rate since time elapsed is unknown.
+    expect(data[7]).to.match(/         mean rate = .* events\/second/);
+    expect(data[8]).to.equal('     1-minute rate =  0.00 events/second');
+    expect(data[9]).to.equal('     5-minute rate =  0.00 events/second');
+    expect(data[10]).to.equal('    15-minute rate =  0.00 events/second');
+    expect(data[11]).to.equal('');
+    expect(data[12]).to.equal('Timers -------------------------------------------------------------------------');
+    expect(data[13]).to.equal('myapp.Timer tag3-timer="timertag_helper" ');
+    expect(data[14]).to.equal('             count = 100');
+    expect(data[15]).to.match(/         mean rate = .* events\/second/);
+    expect(data[16]).to.equal('     1-minute rate =  0.00 events/second');
+    expect(data[17]).to.equal('     5-minute rate =  0.00 events/second');
+    expect(data[18]).to.equal('    15-minute rate =  0.00 events/second');
+    expect(data[19]).to.equal('               min =  1.00 milliseconds');
+    expect(data[20]).to.equal('               max = 100.00 milliseconds');
+    expect(data[21]).to.equal('              mean = 50.50 milliseconds');
+    expect(data[22]).to.equal('            stddev = 29.01 milliseconds');
+    expect(data[23]).to.equal('              50% <= 50.50 milliseconds');
+    expect(data[24]).to.equal('              75% <= 75.75 milliseconds');
+    expect(data[25]).to.equal('              95% <= 95.95 milliseconds');
+    expect(data[26]).to.equal('              98% <= 98.98 milliseconds');
+    expect(data[27]).to.equal('              99% <= 99.99 milliseconds');
+    expect(data[28]).to.equal('            99.9% <= 100.00 milliseconds');
+    expect(data[29]).to.equal('');
+    expect(data[30]).to.equal('Histograms ---------------------------------------------------------------------');
+    expect(data[31]).to.equal('myapp.Histogram tag2-histogram="histogramtag_helper" ');
     expect(data[32]).to.equal('             count = 100');
     expect(data[33]).to.equal('               min =  2.00');
     expect(data[34]).to.equal('               max = 200.00');


### PR DESCRIPTION
As per:
https://docs.wavefront.com/wavefront_data_format.html#wavefront-data-format-fields
pointTags values for the wavefront reporter are supposed to be wrapped in `"` characters.  This library did not do that wrapping, which can result in missing tags.  This fixes that.

Also adds support for sending tags through to the console reporter.

Additionally it comments out a number of console.log statements that seem to have been left in for debugging purposes in special conditions.  If these are intentional, then the project should really adopt a logging solution like [winston](https://www.npmjs.com/package/winston) or [debug](https://www.npmjs.com/package/debug) so that people who use the library can control the logging and turn them off.