### PR TITLE
Making node client compatible with node version 6.0.0 

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -3,7 +3,7 @@
 function tagger(tags, globaltags) {
   // return tags in the format 'env="prod" service="qa"'
   // Also merges the global tags with metric tags
-  let mergedTags = {...tags, ...globaltags};
+  let mergedTags = Object.assign({}, tags, globaltags);
   return Object.keys(mergedTags).map(
     key => `${key}="${escapeQuotes(mergedTags[key])}"`).join(' ');
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Wavefront Reporters for metrics",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=8.1.0 <10.4.0"
+    "node": ">=6.0.0"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
This effort is to support AWS lambda runtime nodejsv6.10.

Please review: @vikramraman @sushantdewan123 @aliu-vmware 

Thank you,
Anil