### PR TITLE
Allow metrics with same metric name and different set of tags 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ m.mark(1);
 
 // Timer
 let t = new metrics.Timer();
-registry.addTaggedMetric("request.timer", m, {"key1":"val1"});
+registry.addTaggedMetric("request.timer", t, {"key1":"val1"});
 t.update(50);
 ```
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -28,10 +28,11 @@ function encodeKey(metricName, tags) {
 }
 
 function decodeKey(key) {
+  var [metricName, tags] = [key, null];
   if (key.indexOf(tagSeparator) > -1) {
-    return key.split(tagSeparator);
+    [metricName, tags] = key.split(tagSeparator);
   }
-  return [key, null];
+  return [metricName, tags];
 }
 
 module.exports = {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -23,8 +23,12 @@ function encodeKey(metricName, tags) {
     return metricName;
   }
   // Sort the tags based on their keys to ensure we don't duplicate metrics if the same tags come out of order.
-  var tagsJson = JSON.stringify(tags, Object.keys(tags).sort());
-  return metricName + tagSeparator + tagsJson ;
+  var jsonArray = Object.keys(tags).sort().map(key => [key, tags[key]]);
+  var tagsJson = {};
+  jsonArray.forEach(function(tagkv) {
+    tagsJson[tagkv[0]] = tagkv[1];
+  })
+  return metricName + tagSeparator + JSON.stringify(tagsJson) ;
 }
 
 function decodeKey(key) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const tagSeparator = "-tags=";
+
 function tagger(tags, globaltags) {
   // return tags in the format 'env="prod" service="qa"'
   // Also merges the global tags with metric tags
@@ -16,8 +18,26 @@ function isEmpty(value) {
   return typeof value == 'string' && !value.trim() || typeof value == 'undefined' || value === null;
 }
 
+function encodeKey(metricName, tags) {
+  if (isEmpty(tags)) {
+    return metricName;
+  }
+  // Sort the tags based on their keys to ensure we don't duplicate metrics if the same tags come out of order.
+  var tagsJson = JSON.stringify(tags, Object.keys(tags).sort());
+  return metricName + tagSeparator + tagsJson ;
+}
+
+function decodeKey(key) {
+  if (key.indexOf(tagSeparator) > -1) {
+    return key.split(tagSeparator);
+  }
+  return [key, null];
+}
+
 module.exports = {
   tagger,
   escapeQuotes,
-  isEmpty
+  isEmpty,
+  encodeKey,
+  decodeKey
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -23,12 +23,8 @@ function encodeKey(metricName, tags) {
     return metricName;
   }
   // Sort the tags based on their keys to ensure we don't duplicate metrics if the same tags come out of order.
-  var jsonArray = Object.keys(tags).sort().map(key => [key, tags[key]]);
-  var tagsJson = {};
-  jsonArray.forEach(function(tagkv) {
-    tagsJson[tagkv[0]] = tagkv[1];
-  })
-  return metricName + tagSeparator + JSON.stringify(tagsJson) ;
+  var tagsArray = Object.keys(tags).sort().map(key => [key, tags[key]]);
+  return metricName + tagSeparator + JSON.stringify(tagsArray) ;
 }
 
 function decodeKey(key) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -11,16 +11,10 @@ class Registry extends Report {
   }
 
   addTaggedMetric(metricName, metric, tags) {
-    this.addMetric(metricName, metric);
-    if (!helper.isEmpty(tags)) {
-      this.trackedTags[metricName] = tags;
-    }
+    const encodedName = helper.encodeKey(metricName, tags);
+    this.addMetric(encodedName, metric);
   }
 
-  getTags(metricName) {
-    if (!this.trackedTags[metricName]) { return; }
-    return this.trackedTags[metricName];
-  }
 }
 
 module.exports = Registry;

--- a/lib/wavefront-direct-reporter.js
+++ b/lib/wavefront-direct-reporter.js
@@ -128,35 +128,34 @@ class WavefrontDirectReporter extends ScheduledReporter {
   }
 
   appendCounter(counter, points) {
-    const nameAndTags = this.getDecodedKey(counter);
-    points.push(formatter.counterPoint(counter, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(counter);
+    points.push(formatter.counterPoint(counter, metricName, this.prefix, '', tags));
   }
 
   appendGauge(gauge, points) {
-    const nameAndTags = this.getDecodedKey(gauge);
-    points.push(formatter.gaugePoint(gauge, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(gauge);
+    points.push(formatter.gaugePoint(gauge, metricName, this.prefix, '', tags));
   }
 
   appendMeter(meter, points) {
-    const nameAndTags = this.getDecodedKey(meter);
-    points.push(...formatter.meterPoints(meter, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(meter);
+    points.push(...formatter.meterPoints(meter, metricName, this.prefix, '', tags));
   }
 
   appendTimer(timer, points) {
-    const nameAndTags = this.getDecodedKey(timer);
-    points.push(...formatter.timerPoints(timer, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(timer);
+    points.push(...formatter.timerPoints(timer, metricName, this.prefix, '', tags));
   }
 
   appendHistogram(histogram, points) {
-    const nameAndTags = this.getDecodedKey(histogram);
-    points.push(...formatter.histoPoints(histogram, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(histogram);
+    points.push(...formatter.histoPoints(histogram, metricName, this.prefix, '', tags));
   }
 
   getDecodedKey(metric) {
-    const nameAndTags = helper.decodeKey(metric.name)
-    const metricTags = JSON.parse(nameAndTags[1]);
-    const tags = helper.tagger(metricTags, this.globaltags);
-    return [nameAndTags[0], tags];
+    const [metricName, metricTags] = helper.decodeKey(metric.name)
+    const tags = helper.tagger(JSON.parse(metricTags), this.globaltags);
+    return [metricName, tags];
   }
 }
 

--- a/lib/wavefront-direct-reporter.js
+++ b/lib/wavefront-direct-reporter.js
@@ -128,28 +128,35 @@ class WavefrontDirectReporter extends ScheduledReporter {
   }
 
   appendCounter(counter, points) {
-    let tags = helper.tagger(this.registry.getTags(counter.name), this.globaltags);
-    points.push(formatter.counterPoint(counter, this.prefix, '', tags));
+    const nameAndTags = this.getDecodedKey(counter);
+    points.push(formatter.counterPoint(counter, nameAndTags[0], this.prefix, '', nameAndTags[1]));
   }
 
   appendGauge(gauge, points) {
-    let tags = helper.tagger(this.registry.getTags(gauge.name), this.globaltags);
-    points.push(formatter.gaugePoint(gauge, this.prefix, '', tags));
+    const nameAndTags = this.getDecodedKey(gauge);
+    points.push(formatter.gaugePoint(gauge, nameAndTags[0], this.prefix, '', nameAndTags[1]));
   }
 
   appendMeter(meter, points) {
-    let tags = helper.tagger(this.registry.getTags(meter.name), this.globaltags);
-    points.push(...formatter.meterPoints(meter, this.prefix, '', tags));
+    const nameAndTags = this.getDecodedKey(meter);
+    points.push(...formatter.meterPoints(meter, nameAndTags[0], this.prefix, '', nameAndTags[1]));
   }
 
   appendTimer(timer, points) {
-    let tags = helper.tagger(this.registry.getTags(timer.name), this.globaltags);
-    points.push(...formatter.timerPoints(timer, this.prefix, '', tags));
+    const nameAndTags = this.getDecodedKey(timer);
+    points.push(...formatter.timerPoints(timer, nameAndTags[0], this.prefix, '', nameAndTags[1]));
   }
 
   appendHistogram(histogram, points) {
-    let tags = helper.tagger(this.registry.getTags(histogram.name), this.globaltags);
-    points.push(...formatter.histoPoints(histogram, this.prefix, '', tags));
+    const nameAndTags = this.getDecodedKey(histogram);
+    points.push(...formatter.histoPoints(histogram, nameAndTags[0], this.prefix, '', nameAndTags[1]));
+  }
+
+  getDecodedKey(metric) {
+    const nameAndTags = helper.decodeKey(metric.name)
+    const metricTags = JSON.parse(nameAndTags[1]);
+    const tags = helper.tagger(metricTags, this.globaltags);
+    return [nameAndTags[0], tags];
   }
 }
 

--- a/lib/wavefront-direct-reporter.js
+++ b/lib/wavefront-direct-reporter.js
@@ -153,8 +153,15 @@ class WavefrontDirectReporter extends ScheduledReporter {
   }
 
   getDecodedKey(metric) {
-    const [metricName, metricTags] = helper.decodeKey(metric.name)
-    const tags = helper.tagger(JSON.parse(metricTags), this.globaltags);
+    const [metricName, metricTagsArray] = helper.decodeKey(metric.name)
+    const tagsArray = JSON.parse(metricTagsArray);
+    var metricTags = {};
+    if (tagsArray && tagsArray.length) {
+      tagsArray.forEach(function([key, value]) {
+        metricTags[key] = value;
+      })
+    }
+    const tags = helper.tagger(metricTags, this.globaltags);
     return [metricName, tags];
   }
 }

--- a/lib/wavefront-metrics-formatter.js
+++ b/lib/wavefront-metrics-formatter.js
@@ -3,60 +3,60 @@
 const delta = require('./delta');
 const Histogram = require('metrics').Histogram;
 
-function counterPoint(counter, prefix, ts, tags) {
-  if (delta.hasDeltaPrefix(counter.name)) {
+function counterPoint(counter, metricName, prefix, ts, tags) {
+  if (delta.hasDeltaPrefix(metricName)) {
     const value = counter.count;
-    const name = delta.resetAndGetName(counter, prefix, counter.name, value);
+    const name = delta.resetAndGetName(counter, prefix, metricName, value);
     return pointLine('', name, '', value, ts, tags);
   } else {
-    return pointLine(prefix, counter.name, '', counter.count, ts, tags);
+    return pointLine(prefix, metricName, '', counter.count, ts, tags);
   }
 }
 
-function gaugePoint(gauge, prefix, ts, tags) {
-  return pointLine(prefix, gauge.name, '', gauge.value, ts, tags);
+function gaugePoint(gauge, metricName, prefix, ts, tags) {
+  return pointLine(prefix, metricName, '', gauge.value, ts, tags);
 }
 
-function meterPoints(meter, prefix, ts, tags) {
+function meterPoints(meter, metricName, prefix, ts, tags) {
   let points = [];
-  points.push(pointLine(prefix, meter.name, '.count', meter.count, ts, tags));
-  points.push(pointLine(prefix, meter.name, '.mean_rate', meter.meanRate(), ts, tags));
-  points.push(pointLine(prefix, meter.name, '.m1_rate', meter.oneMinuteRate(), ts, tags));
-  points.push(pointLine(prefix, meter.name, '.m5_rate', meter.fiveMinuteRate(), ts, tags));
-  points.push(pointLine(prefix, meter.name, '.m15_rate', meter.fifteenMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.count', meter.count, ts, tags));
+  points.push(pointLine(prefix, metricName, '.mean_rate', meter.meanRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m1_rate', meter.oneMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m5_rate', meter.fiveMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m15_rate', meter.fifteenMinuteRate(), ts, tags));
   return points;
 }
 
-function timerPoints(timer, prefix, ts, tags) {
+function timerPoints(timer, metricName, prefix, ts, tags) {
   let points = [];
-  points.push(pointLine(prefix, timer.name, '.count', timer.count(), ts, tags));
-  points.push(pointLine(prefix, timer.name, '.mean_rate', timer.meanRate(), ts, tags));
-  points.push(pointLine(prefix, timer.name, '.m1_rate', timer.oneMinuteRate(), ts, tags));
-  points.push(pointLine(prefix, timer.name, '.m5_rate', timer.fiveMinuteRate(), ts, tags));
-  points.push(pointLine(prefix, timer.name, '.m15_rate', timer.fifteenMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.count', timer.count(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.mean_rate', timer.meanRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m1_rate', timer.oneMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m5_rate', timer.fiveMinuteRate(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.m15_rate', timer.fifteenMinuteRate(), ts, tags));
   return points.concat(histoPoints(timer, prefix, ts, tags));
 }
 
-function histoPoints(histo, prefix, ts, tags) {
+function histoPoints(histo, metricName, prefix, ts, tags) {
   let points = [];
   const isHisto = histo instanceof Histogram;
   if (isHisto) {
     // send count if a histogram, otherwise assume this metric is being
     // printed as part of another (like a timer).
-    points.push(pointLine(prefix, histo.name, '.count', histo.count, ts, tags));
+    points.push(pointLine(prefix, metricName, '.count', histo.count, ts, tags));
   }
 
   let percentiles = histo.percentiles([.50,.75,.95,.98,.99,.999]);
-  points.push(pointLine(prefix, histo.name, '.min', isHisto? histo.min : histo.min(), ts, tags));
-  points.push(pointLine(prefix, histo.name, '.mean', histo.mean(), ts, tags));
-  points.push(pointLine(prefix, histo.name, '.max', isHisto ? histo.max: histo.max(), ts, tags));
-  points.push(pointLine(prefix, histo.name, '.stddev', histo.stdDev(), ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p50', percentiles[.50], ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p75', percentiles[.75], ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p95', percentiles[.95], ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p98', percentiles[.98], ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p99', percentiles[.99], ts, tags));
-  points.push(pointLine(prefix, histo.name, '.p999', percentiles[.999], ts, tags));
+  points.push(pointLine(prefix, metricName, '.min', isHisto? histo.min : histo.min(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.mean', histo.mean(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.max', isHisto ? histo.max: histo.max(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.stddev', histo.stdDev(), ts, tags));
+  points.push(pointLine(prefix, metricName, '.p50', percentiles[.50], ts, tags));
+  points.push(pointLine(prefix, metricName, '.p75', percentiles[.75], ts, tags));
+  points.push(pointLine(prefix, metricName, '.p95', percentiles[.95], ts, tags));
+  points.push(pointLine(prefix, metricName, '.p98', percentiles[.98], ts, tags));
+  points.push(pointLine(prefix, metricName, '.p99', percentiles[.99], ts, tags));
+  points.push(pointLine(prefix, metricName, '.p999', percentiles[.999], ts, tags));
   return points;
 }
 

--- a/lib/wavefront-proxy-reporter.js
+++ b/lib/wavefront-proxy-reporter.js
@@ -104,38 +104,37 @@ class WavefrontProxyReporter extends ScheduledReporter {
   }
 
   reportCounter(counter, timestamp) {
-    const nameAndTags = this.getDecodedKey(counter);
-    this.send(formatter.counterPoint(counter, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(counter);
+    this.send(formatter.counterPoint(counter, metricName, this.prefix, timestamp, tags));
   }
 
   reportGauge(gauge, timestamp) {
-    const nameAndTags = this.getDecodedKey(gauge);
-    this.send(formatter.gaugePoint(gauge, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]));
+    const [metricName, tags] = this.getDecodedKey(gauge);
+    this.send(formatter.gaugePoint(gauge, metricName, this.prefix, timestamp, tags));
   }
 
   reportMeter(meter, timestamp) {
-    const nameAndTags = this.getDecodedKey(meter);
-    let points = formatter.meterPoints(meter, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
+    const [metricName, tags] = this.getDecodedKey(meter);
+    let points = formatter.meterPoints(meter, metricName, this.prefix, timestamp, tags);
     points.forEach(pointLine => this.send(pointLine));
   }
 
   reportTimer(timer, timestamp) {
-    const nameAndTags = this.getDecodedKey(timer);
-    let points = formatter.timerPoints(timer, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
+    const [metricName, tags] = this.getDecodedKey(timer);
+    let points = formatter.timerPoints(timer, metricName, this.prefix, timestamp, tags);
     points.forEach(pointLine => this.send(pointLine));
   }
 
   reportHistogram(histogram, timestamp) {
-    const nameAndTags = this.getDecodedKey(histogram);
-    let points = formatter.histoPoints(histogram, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
+    const [metricName, tags] = this.getDecodedKey(histogram);
+    let points = formatter.histoPoints(histogram, metricName, this.prefix, timestamp, tags);
     points.forEach(pointLine => this.send(pointLine));
   }
 
   getDecodedKey(metric) {
-    const nameAndTags = helper.decodeKey(metric.name)
-    const metricTags = JSON.parse(nameAndTags[1]);
-    const tags = helper.tagger(metricTags, this.globaltags);
-    return [nameAndTags[0], tags];
+    const [metricName, metricTags] = helper.decodeKey(metric.name)
+    const tags = helper.tagger(JSON.parse(metricTags), this.globaltags);
+    return [metricName, tags];
   }
 }
 

--- a/lib/wavefront-proxy-reporter.js
+++ b/lib/wavefront-proxy-reporter.js
@@ -132,8 +132,15 @@ class WavefrontProxyReporter extends ScheduledReporter {
   }
 
   getDecodedKey(metric) {
-    const [metricName, metricTags] = helper.decodeKey(metric.name)
-    const tags = helper.tagger(JSON.parse(metricTags), this.globaltags);
+    const [metricName, metricTagsArray] = helper.decodeKey(metric.name)
+    const tagsArray = JSON.parse(metricTagsArray);
+    var metricTags = {};
+    if (tagsArray && tagsArray.length) {
+      tagsArray.forEach(function([key, value]) {
+        metricTags[key] = value;
+      })
+    }
+    const tags = helper.tagger(metricTags, this.globaltags);
     return [metricName, tags];
   }
 }

--- a/lib/wavefront-proxy-reporter.js
+++ b/lib/wavefront-proxy-reporter.js
@@ -105,7 +105,7 @@ class WavefrontProxyReporter extends ScheduledReporter {
 
   reportCounter(counter, timestamp) {
     const nameAndTags = this.getDecodedKey(counter);
-    this.send(formatter.counterPoint(counter, this.prefix, timestamp, nameAndTags[1]));
+    this.send(formatter.counterPoint(counter, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]));
   }
 
   reportGauge(gauge, timestamp) {

--- a/lib/wavefront-proxy-reporter.js
+++ b/lib/wavefront-proxy-reporter.js
@@ -104,31 +104,38 @@ class WavefrontProxyReporter extends ScheduledReporter {
   }
 
   reportCounter(counter, timestamp) {
-    let tags = helper.tagger(this.registry.getTags(counter.name), this.globaltags);
-    this.send(formatter.counterPoint(counter, this.prefix, timestamp, tags));
+    const nameAndTags = this.getDecodedKey(counter);
+    this.send(formatter.counterPoint(counter, this.prefix, timestamp, nameAndTags[1]));
   }
 
   reportGauge(gauge, timestamp) {
-    let tags = helper.tagger(this.registry.getTags(gauge.name), this.globaltags);
-    this.send(formatter.gaugePoint(gauge, this.prefix, timestamp, tags));
+    const nameAndTags = this.getDecodedKey(gauge);
+    this.send(formatter.gaugePoint(gauge, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]));
   }
 
   reportMeter(meter, timestamp) {
-    let tags = helper.tagger(this.registry.getTags(meter.name), this.globaltags);
-    let points = formatter.meterPoints(meter, this.prefix, timestamp, tags);
+    const nameAndTags = this.getDecodedKey(meter);
+    let points = formatter.meterPoints(meter, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
     points.forEach(pointLine => this.send(pointLine));
   }
 
   reportTimer(timer, timestamp) {
-    let tags = helper.tagger(this.registry.getTags(timer.name), this.globaltags);
-    let points = formatter.timerPoints(timer, this.prefix, timestamp, tags);
+    const nameAndTags = this.getDecodedKey(timer);
+    let points = formatter.timerPoints(timer, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
     points.forEach(pointLine => this.send(pointLine));
   }
 
   reportHistogram(histogram, timestamp) {
-    let tags = helper.tagger(this.registry.getTags(histogram.name), this.globaltags);
-    let points = formatter.histoPoints(histogram, this.prefix, timestamp, tags);
+    const nameAndTags = this.getDecodedKey(histogram);
+    let points = formatter.histoPoints(histogram, nameAndTags[0], this.prefix, timestamp, nameAndTags[1]);
     points.forEach(pointLine => this.send(pointLine));
+  }
+
+  getDecodedKey(metric) {
+    const nameAndTags = helper.decodeKey(metric.name)
+    const metricTags = JSON.parse(nameAndTags[1]);
+    const tags = helper.tagger(metricTags, this.globaltags);
+    return [nameAndTags[0], tags];
   }
 }
 

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -9,10 +9,10 @@ describe('counterPoint', function() {
     counter.name = "requests.counter";
     counter.inc();
 
-    let point = formatter.counterPoint(counter, 'test', '', "key1=\"val1\"");
+    let point = formatter.counterPoint(counter, counter.name, 'test', '', "key1=\"val1\"");
     expect(point).to.be.equal('test.requests.counter 1 key1=\"val1\"');
 
-    point = formatter.counterPoint(counter, 'test', '1350450000', "key1=\"val1\"")
+    point = formatter.counterPoint(counter, counter.name, 'test', '1350450000', "key1=\"val1\"")
     expect(point).to.be.equal('test.requests.counter 1 1350450000 key1=\"val1\"');
   });
 });
@@ -23,7 +23,7 @@ describe('deltaPoint', function() {
     counter.name = delta.deltaCounterName("requests.counter");
     counter.inc();
 
-    let point = formatter.counterPoint(counter, 'test', '', "key1=\"val1\"");
+    let point = formatter.counterPoint(counter, counter.name, 'test', '', "key1=\"val1\"");
     expect(point).to.be.equal('\u2206test.requests.counter 1 key1=\"val1\"');
   });
 });
@@ -33,10 +33,10 @@ describe('gaugePoint', function() {
     const gauge = new metrics.Gauge(2.2);
     gauge.name = "requests.value";
 
-    let point = formatter.gaugePoint(gauge, 'test', '', "key1=\"val1\"");
+    let point = formatter.gaugePoint(gauge, gauge.name, 'test', '', "key1=\"val1\"");
     expect(point).to.be.equal('test.requests.value 2.2 key1=\"val1\"');
 
-    point = formatter.gaugePoint(gauge, 'test', '1350450000', "key1=\"val1\"")
+    point = formatter.gaugePoint(gauge, gauge.name, 'test', '1350450000', "key1=\"val1\"")
     expect(point).to.be.equal('test.requests.value 2.2 1350450000 key1=\"val1\"');
   });
 });
@@ -47,7 +47,7 @@ describe('meterPoints', function() {
     meter.name = "requests.meter";
     meter.mark(10);
 
-    let points = formatter.meterPoints(meter, 'test', '', "key1=\"val1\"");
+    let points = formatter.meterPoints(meter, meter.name, 'test', '', "key1=\"val1\"");
     console.log(points);
     expect(5).to.be.equal(points.length);
     expect(points[0]).to.be.equal('test.requests.meter.count 10 key1=\"val1\"');
@@ -60,7 +60,7 @@ describe('timerPoints', function() {
     timer.name = "requests.timer";
     timer.update(10);
 
-    let points = formatter.timerPoints(timer, 'test', '', "key1=\"val1\"");
+    let points = formatter.timerPoints(timer, timer.name, 'test', '', "key1=\"val1\"");
     console.log(points);
     expect(15).to.be.equal(points.length);
     expect(points[0]).to.be.equal('test.requests.timer.count 1 key1=\"val1\"');
@@ -73,7 +73,7 @@ describe('histoPoints', function() {
     histo.name = "requests.histo";
     histo.update(10);
 
-    let points = formatter.histoPoints(histo, 'test', '', "key1=\"val1\"");
+    let points = formatter.histoPoints(histo, histo.name, 'test', '', "key1=\"val1\"");
     console.log(points);
     expect(11).to.be.equal(points.length);
     expect(points[0]).to.be.equal('test.requests.histo.count 1 key1=\"val1\"');

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,10 +4,10 @@ const helper = require('../lib/helper');
 describe('encodeKey', function() {
   it('Validate encode key', function() {
     let key11 = helper.encodeKey('http.request', {"key1":"val1"});
-    expect(key11).to.be.equal('http.request-tags={"key1":"val1"}');
+    expect(key11).to.be.equal('http.request-tags=[["key1","val1"]]');
 
     let key12 = helper.encodeKey('http.request', {"key1":"val2"});
-    expect(key12).to.be.equal('http.request-tags={"key1":"val2"}');
+    expect(key12).to.be.equal('http.request-tags=[["key1","val2"]]');
 
     let key = helper.encodeKey('http.request');
     expect(key).to.be.equal('http.request')

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,0 +1,29 @@
+const expect = require('chai').expect;
+const helper = require('../lib/helper');
+
+describe('encodeKey', function() {
+  it('Validate encode key', function() {
+    let key11 = helper.encodeKey('http.request', {"key1":"val1"});
+    expect(key11).to.be.equal('http.request-tags={"key1":"val1"}');
+
+    let key12 = helper.encodeKey('http.request', {"key1":"val2"});
+    expect(key12).to.be.equal('http.request-tags={"key1":"val2"}');
+
+    let key = helper.encodeKey('http.request');
+    expect(key).to.be.equal('http.request')
+  });
+});
+
+describe('decodeKey', function() {
+  it('Validate decode key', function() {
+    let key11 = 'http.request-tags={"key1":"val1","key2":"val2"}';
+    let decodedKey = helper.decodeKey(key11);
+    expect(decodedKey[0]).to.be.equal('http.request');
+    expect(decodedKey[1]).to.be.equal('{"key1":"val1","key2":"val2"}');
+
+    let key = 'http.request';
+    decodedKey = helper.decodeKey(key);
+    expect(decodedKey[0]).to.be.equal('http.request');
+    expect(decodedKey[1]).to.be.equal(null);
+  });
+});


### PR DESCRIPTION
Allow metrics with same metric name with different set of tags to be reported to wavefront.