### PR TITLE
Fix bug histogram metrics appear at top level

### DIFF
--- a/lib/wavefront-metrics-formatter.js
+++ b/lib/wavefront-metrics-formatter.js
@@ -34,7 +34,7 @@ function timerPoints(timer, metricName, prefix, ts, tags) {
   points.push(pointLine(prefix, metricName, '.m1_rate', timer.oneMinuteRate(), ts, tags));
   points.push(pointLine(prefix, metricName, '.m5_rate', timer.fiveMinuteRate(), ts, tags));
   points.push(pointLine(prefix, metricName, '.m15_rate', timer.fifteenMinuteRate(), ts, tags));
-  return points.concat(histoPoints(timer, prefix, ts, tags));
+  return points.concat(histoPoints(timer, metricName, prefix, ts, tags));
 }
 
 function histoPoints(histo, metricName, prefix, ts, tags) {


### PR DESCRIPTION
End-to-end testing done, and histograms can be generated under the timer metric's prefix.